### PR TITLE
v1.0.26 improved PHP 8.3 compatibility

### DIFF
--- a/.idea/inspectionProfiles/Moodle_CodeSniffer.xml
+++ b/.idea/inspectionProfiles/Moodle_CodeSniffer.xml
@@ -565,7 +565,6 @@
     <inspection_tool class="CssInvalidHtmlTagReference" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CssInvalidImport" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CssInvalidMediaFeature" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="CssInvalidNestedSelector" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CssInvalidPropertyValue" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CssInvalidPseudoSelector" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CssMissingComma" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -831,7 +830,6 @@
     <inspection_tool class="GroovyUnusedIncOrDec" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GroovyVariableNotAssigned" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GrpcSchemes" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HCLBlockConflictingProperties" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="HCLBlockMissingProperty" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HCLDeprecatedElement" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
@@ -1348,7 +1346,9 @@
     <inspection_tool class="PhpDuplicateSwitchCaseBodyInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PhpDuplicatedCharacterInStrFunctionCallInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PhpDynamicAsStaticMethodCallInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PhpDynamicFieldDeclarationInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PhpDynamicFieldDeclarationInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="PHP82_SEVERITY" value="ERROR" />
+    </inspection_tool>
     <inspection_tool class="PhpEchoOpenTagInspection" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="PhpElementIsNotAvailableInCurrentPhpVersionInspection" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="PhpExceptionImmediatelyRethrownInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />

--- a/.idea/scopes/kialo.xml
+++ b/.idea/scopes/kialo.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="kialo" pattern="file:*.php&amp;&amp;!file[mod_kialo]:development//*" />
+</component>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### v1.0.26 (Build - 2023121501)
+
+* Improved compatibility with future PHP versions.
+
 ### v1.0.25 (Build - 2023112901)
 
 * Minor internal improvements

--- a/development/README.md
+++ b/development/README.md
@@ -5,7 +5,7 @@
 * Git
 * PHP composer (https://getcomposer.org/)
   * on macOS you can install via `brew install composer`
-* PHP 7.4 or higher
+* PHP 7.4 or PHP 8.2
   * If you installed composer `brew`, this should already be installed
 * Docker (https://www.docker.com/)
 

--- a/tests/classes/lti_flow_test.php
+++ b/tests/classes/lti_flow_test.php
@@ -98,6 +98,24 @@ class lti_flow_test extends \advanced_testcase {
     private $cmid;
 
     /**
+     * Copy of $_SERVER superglobal before the test.
+     * @var array|null
+     */
+    private $server;
+
+    /**
+     * Copy of $_ENV superglobal before the test.
+     * @var array|null
+     */
+    private $env;
+
+    /**
+     * Copy of $_GET superglobal before the test.
+     * @var array|null
+     */
+    private $get;
+
+    /**
      * In production the tool's (Kialo's) public key is downloaded from the platform (Moodle) during the LTI flow.
      * For this test we generate a new keypair and override the tool keychain in kialo_config, instead.    *
      *

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'mod_kialo';
 
 // See https://moodledev.io/docs/apis/commonfiles/version.php.
-$plugin->version = 2023112901;  // Must be incremented for each new release!
-$plugin->release = '1.0.25';    // Semantic version.
+$plugin->version = 2023121501;  // Must be incremented for each new release!
+$plugin->release = '1.0.26';    // Semantic version.
 
 // Officially we require PHP 7.4. The first Moodle version that requires this as a minimum is Moodle 4.1.
 // But technically this plugin also runs on older Moodle versions, as long as they run on PHP 7.4,


### PR DESCRIPTION
Starting from PHP 8.3 dynamic class property declares are deprecated. Added inspection and remove instances of this in our code.