### PR TITLE
PM-45856 prevent kialo icon colors from being altered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### v1.1.1 (Build - 2024071001)
+
+* Always render Kialo icon on neutral background
+* Prevent Kialo icon colors from being altered
+
 ### v1.1.0 (Build - 2024053101)
 
 * Moodle 4.4 compatibility

--- a/lib.php
+++ b/lib.php
@@ -29,11 +29,6 @@
  * @return true | string | null Truthy if the feature is supported, null otherwise.
  */
 function kialo_supports($feature) {
-    if (defined("FEATURE_MOD_PURPOSE") && $feature === FEATURE_MOD_PURPOSE) {
-        // Moodle 4.0 and newer.
-        return MOD_PURPOSE_COLLABORATION;
-    }
-
     switch ($feature) {
         case FEATURE_BACKUP_MOODLE2:
             return true;
@@ -48,7 +43,6 @@ function kialo_supports($feature) {
 
 /**
  * Prevent the Kialo icon from having its colors modified on Moodle >= 4.4.
- * For < 4.4 this is handled in style.css.
  */
 function kialo_is_branded(): bool {
     return true;

--- a/lib.php
+++ b/lib.php
@@ -47,6 +47,14 @@ function kialo_supports($feature) {
 }
 
 /**
+ * Prevent the Kialo icon from having its colors modified on Moodle >= 4.4.
+ * For < 4.4 this is handled in style.css.
+ */
+function kialo_is_branded(): bool {
+    return true;
+}
+
+/**
  * Saves a new instance of the mod_kialo into the database.
  *
  * Given an object containing all the necessary data, (defined by the form

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,9 @@
+/*
+ * Prevent the Kialo icon from having its colors modified on Moodle < 4.4.
+ * For >= 4.4 this is handled in `kialo_is_branded` in `lib.php`.
+ *
+ * This long-winded selector is used to override the moodle selectors applying the filter.
+ */
+.activityiconcontainer.collaboration.modicon_kialo .activityicon:not(.nofilter) {
+    filter: unset;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,0 @@
-/*
- * Prevent the Kialo icon from having its colors modified on Moodle < 4.4.
- * For >= 4.4 this is handled in `kialo_is_branded` in `lib.php`.
- *
- * This long-winded selector is used to override the moodle selectors applying the filter.
- */
-.activityiconcontainer.collaboration.modicon_kialo .activityicon:not(.nofilter) {
-    filter: unset;
-}

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -59,7 +59,7 @@ final class lib_test extends \advanced_testcase {
 
         // Moodle 4.0 and newer.
         if (defined("FEATURE_MOD_PURPOSE")) {
-            $this->assertEquals(MOD_PURPOSE_COLLABORATION, kialo_supports(FEATURE_MOD_PURPOSE));
+            $this->assertNull(kialo_supports(FEATURE_MOD_PURPOSE));
         }
     }
 

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'mod_kialo';
 
 // See https://moodledev.io/docs/apis/commonfiles/version.php.
-$plugin->version = 2024053101;  // Must be incremented for each new release!
-$plugin->release = '1.1.0';    // Semantic version.
+$plugin->version = 2024071001;  // Must be incremented for each new release!
+$plugin->release = '1.1.1';    // Semantic version.
 
 // Officially we require PHP 7.4. The first Moodle version that requires this as a minimum is Moodle 4.1.
 // But technically this plugin also runs on older Moodle versions, as long as they run on PHP 7.4,


### PR DESCRIPTION
Mark the Kialo plugin as "branded" to prevent its icon colors from being inverted (Moodle 4.4) or white (Moodle <4.4).