### PR TITLE
[tooling] try running Moodle CI for latest Moodle version already

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -46,14 +46,18 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.3'  # max. supported version by Moodle 4.4 (as of writing)
-        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_404_STABLE' ]  # LTS & latest.
+        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_404_STABLE', 'main' ]  # LTS & latest.
         database: [ pgsql ]  # We don't use any database specific features, and our test sites run mariadb already.
         exclude:
           # Moodle 4.4+ requires PHP 8.1+
           - php: '8.0'
             moodle-branch: 'MOODLE_404_STABLE'
+          - php: '8.0'
+            moodle-branch: 'main'
           - php: '7.4'
             moodle-branch: 'MOODLE_404_STABLE'
+          - php: '7.4'
+            moodle-branch: 'main'
           # Moodle 4.1 does not support PHP 8.3
           - php: '8.3'
             moodle-branch: 'MOODLE_401_STABLE'


### PR DESCRIPTION
This simply adds Moodle's current `main` branch to one of the test scenarios.
Currently this will fail the build if `main` doesn't succeed. Not sure how stable the versions on Moodle's main branch are, but for now I'll keep it like this. If it starts failing often due to unstable versions, we can reconsider making it optional or so.