### PR TITLE
setup by avoiding host.docker.internal

### DIFF
--- a/development/.env.example
+++ b/development/.env.example
@@ -18,6 +18,10 @@ MOODLE_HOST=192.168.X.X:8080
 # which is accessible from within the Kialo Docker container.
 # MOODLE_HOST=moodle:8080
 
+# IP of your developer machine (docker host)
+HOST_IP=192.168.1.123
+
+
 # Moodle branch to use. By default we use the latest version (the `main` branch).
 # If you want to use a specific other version, use the corresponding branch name.
 # For example MOODLE_405_STABLE for Moodle 4.5. See https://github.com/moodle/moodle/branches.

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       # you can override the following by creating a .env file in the same directory as this file
       - TARGET_KIALO_URL=${TARGET_KIALO_URL:-http://localhost:5000}
       - MOODLE_HOST=http://${MOODLE_HOST:-localhost:8080}
+      - HOST_IP=${HOST_IP}
     volumes:
       - './mod_kialo:/var/www/html/mod/kialo'
     depends_on:

--- a/development/moodleimage/entrypoint.sh
+++ b/development/moodleimage/entrypoint.sh
@@ -9,6 +9,6 @@ su - www-data -s /bin/bash -c "php /var/www/html/admin/cli/install.php --non-int
 sed -i '/require_once/i\require_once(__DIR__ . "/config_kialo.php");' /var/www/html/config.php
 
 # Make localhost.kialolabs.com point to the host machine IP address.
-echo "$(dig +short A host.docker.internal | head -n 1) localhost.kialolabs.com" >> /etc/hosts
+echo "$HOST_IP localhost.kialolabs.com" >> /etc/hosts
 
 exec /usr/local/bin/moodle-docker-php-entrypoint "$@"


### PR DESCRIPTION
host.docker.internal did not work for me. According to https://forums.docker.com/t/host-docker-internal-missing-in-linux-ubuntu/137535 it only works for docker desktop. This is an alternative that avoids host.docker.internal