### PR TITLE
update dev composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
       "sed 's|\\${SITENAME}|local|g' $KIALO_ROOT/.github/scripts/populate-moodle-users.sql | docker exec -i mod_kialo-mariadb-1 mariadb --user moodle moodle",
       "docker exec -i mod_kialo-mariadb-1 mariadb --user moodle moodle < $KIALO_ROOT/.github/scripts/populate-moodle-courses-and-groups.sql"
     ],
-    "docker:show-logs":[
+    "docker:logs":[
       "cd development && docker compose logs -f"
     ]
   }

--- a/composer.json
+++ b/composer.json
@@ -79,8 +79,11 @@
       "cd development && docker compose down"
     ],
     "docker:populate-users": [
-      "docker exec -i mod_kialo-mariadb-1 mariadb --user moodle moodle < $KIALO_ROOT/.github/scripts/populate-moodle-users.sql",
+      "sed 's|\\${SITENAME}|local|g' $KIALO_ROOT/.github/scripts/populate-moodle-users.sql | docker exec -i mod_kialo-mariadb-1 mariadb --user moodle moodle",
       "docker exec -i mod_kialo-mariadb-1 mariadb --user moodle moodle < $KIALO_ROOT/.github/scripts/populate-moodle-courses-and-groups.sql"
+    ],
+    "docker:show-logs":[
+      "cd development && docker compose logs -f"
     ]
   }
 }


### PR DESCRIPTION
When updating the populate-moodle-users.sql script I was not aware of the usage in the moodle repo. ([PM-48720](https://mapconv.atlassian.net/browse/PM-48720))

Running locally `composer docker:populate-users` should populate users with emails like teacher-local@kialo.com instead of teacher-${SITENAME}@kialo.com now.

I also added `composer docker:show-logs` to open the logs (I find this helpful - feel free to disagree)

[PM-48720]: https://mapconv.atlassian.net/browse/PM-48720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ