### PR TITLE
PM-49993 Add MOODLE_502_STABLE

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -50,6 +50,7 @@ jobs:
           - 'MOODLE_405_STABLE'
           - 'MOODLE_500_STABLE'
           - 'MOODLE_501_STABLE'
+          - 'MOODLE_502_STABLE'
           - 'main'
         database: [ pgsql ]  # We don't use any database specific features, and our test sites run mariadb already.
         exclude:
@@ -58,6 +59,8 @@ jobs:
             moodle-branch: 'MOODLE_500_STABLE'
           - php: '8.1'
             moodle-branch: 'MOODLE_501_STABLE'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_502_STABLE'
           - php: '8.1'
             moodle-branch: 'main'
           # Moodle 4.5 only supports PHP 8.1-8.3


### PR DESCRIPTION
This adds the `MOODLE_502_STABLE` branch to the CI after Moodle 5.2 was released.