### PR TITLE
PM-50079 fix broken embeds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### v1.6.1 (Build - 2026062503)
+
+* **Fix:** Embedded Kialo discussions and the discussion selection dialog no longer load on recent Moodle versions (4.5.12+, 5.0.8+, 5.1.5+, 5.2.1+), which changed the Moodle session cookie to `SameSite=Lax` (MDL-83526). The plugin now re-issues the LTI authentication request from Moodle's own domain so the session cookie is sent, matching the technique used by Moodle's built-in LTI module.
+
 ### v1.6.0 (Build - 2026040701)
 
 * Updated dependencies.

--- a/classes/kialo_view.php
+++ b/classes/kialo_view.php
@@ -71,6 +71,22 @@ class kialo_view {
     }
 
     /**
+     * Decides whether the current LTI authentication request must be re-issued from Moodle's own origin
+     * before it can be processed. See \mod_kialo\output\repost_page for why this is needed.
+     *
+     * @return bool True if the current request should be reposted from Moodle's origin first.
+     */
+    public static function needs_session_repost(): bool {
+        // Already reposted but still no session => genuinely logged out (e.g. expired); don't loop,
+        // let the normal login flow handle it (the GET repost carries the marker in the query string).
+        if (!empty($_GET['repost'])) {
+            return false;
+        }
+
+        return !isloggedin();
+    }
+
+    /**
      * Writes a response to the client.
      *
      * @param ResponseInterface $response

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -37,4 +37,16 @@ class renderer extends plugin_renderer_base {
         $data = $page->export_for_template($this);
         return parent::render_from_template('mod_kialo/loading_page', $data);
     }
+
+    /**
+     * Defer to template.
+     *
+     * @param repost_page $page
+     *
+     * @return string html for the page
+     */
+    public function render_repost_page(repost_page $page): string {
+        $data = $page->export_for_template($this);
+        return parent::render_from_template('mod_kialo/repost_page', $data);
+    }
 }

--- a/classes/output/repost_page.php
+++ b/classes/output/repost_page.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_kialo\output;
+
+use renderable;
+use renderer_base;
+use stdClass;
+use templatable;
+
+/**
+ * Renders a page that immediately re-submits the current LTI authentication request to Moodle itself.
+ *
+ * Since MDL-83526 (Moodle 4.5.12 / 5.0.8 / 5.1.5 / 5.2.1) the MoodleSession cookie defaults to
+ * SameSite=Lax. When a Kialo discussion is displayed embedded, Kialo redirects the browser back to
+ * the plugin's LTI authentication endpoint (lti_auth.php) from within its own (cross-site) iframe.
+ * Browsers withhold the SameSite=Lax session cookie on that cross-site request, so Moodle considers
+ * the user logged out and authentication fails.
+ *
+ * Reposting the exact same request from a page served by Moodle itself turns it into a same-site
+ * request, so the session cookie is sent and authentication can proceed. This mirrors the approach
+ * used by Moodle core's own mod_lti (see mod/lti/auth.php and MDL-71887).
+ *
+ * @package    mod_kialo
+ * @copyright  2023 onwards, Kialo GmbH <support@kialo-edu.com>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class repost_page implements renderable, templatable {
+    /** @var string The (Moodle) URL the request should be reposted to. */
+    private $url;
+
+    /** @var array List of ["key" => ..., "value" => ...] entries to resubmit as hidden form fields. */
+    private $params;
+
+    /**
+     * Creates a new repost page data container.
+     *
+     * Kialo sends the LTI authentication request as a GET, so the repost is a GET form whose fields land
+     * back in the query string, which is where the LTI library reads the parameters from.
+     *
+     * @param string $url The URL to repost to. It must NOT contain a query string, since the parameters
+     *                     are submitted as the GET form's fields.
+     * @param array $params The original request parameters to resubmit as hidden fields.
+     */
+    public function __construct(string $url, array $params) {
+        $this->url = $url;
+        $this->params = array_map(function ($key) use ($params) {
+            return ["key" => $key, "value" => $params[$key]];
+        }, array_keys($params));
+    }
+
+    /**
+     * Export this data so it can be used as the context for a mustache template.
+     *
+     * @param renderer_base $output
+     * @return stdClass
+     */
+    public function export_for_template(renderer_base $output): stdClass {
+        $data = new stdClass();
+        $data->url = $this->url;
+        $data->params = $this->params;
+        $data->htmltitle = get_string('redirect_title', 'mod_kialo');
+        $data->loadingtext = get_string('redirect_loading', 'mod_kialo');
+        $data->continuetext = get_string('continue');
+        return $data;
+    }
+}

--- a/lti_auth.php
+++ b/lti_auth.php
@@ -33,8 +33,28 @@ require_once(__DIR__ . '/lib.php');
 require_once('vendor/autoload.php');
 
 use mod_kialo\kialo_config;
+use mod_kialo\kialo_view;
 use mod_kialo\lti_flow;
 use mod_kialo\output\loading_page;
+use mod_kialo\output\repost_page;
+
+// Re-issue this request from Moodle's own origin so the SameSite=Lax session cookie is sent in the
+// embedded (cross-site iframe) flow. See \mod_kialo\output\repost_page for the why and how.
+if (kialo_view::needs_session_repost()) {
+    // Avoid setting a fresh anonymous session cookie that would replace the user's real one on the repost.
+    header_remove('Set-Cookie');
+
+    $PAGE->set_context(context_system::instance());
+    $PAGE->set_url('/mod/kialo/lti_auth.php');
+    $PAGE->set_title(get_string('redirect_title', 'mod_kialo'));
+
+    // Kialo sends this request as a GET, so repost it as a GET whose form fields land back in the query
+    // string, which is where the LTI library reads the parameters from.
+    $reposturl = (new moodle_url('/mod/kialo/lti_auth.php'))->out(false);
+    $output = $PAGE->get_renderer('mod_kialo');
+    echo $output->render(new repost_page($reposturl, $_GET));
+    exit;
+}
 
 try {
     $message = lti_flow::lti_auth();

--- a/templates/repost_page.mustache
+++ b/templates/repost_page.mustache
@@ -1,0 +1,121 @@
+{{!
+    This file is part of Moodle - https://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_kialo/repost_page
+
+    Re-submits the current LTI authentication request to Moodle from its own origin so the session
+    cookie is sent. See \mod_kialo\output\repost_page for why this is needed.
+
+    The form auto-submits via JavaScript; a "Continue" button is a manual fallback.
+
+    Context variables required for this template:
+    * url: string, the URL to repost to (no query string; the parameters are submitted as form fields)
+    * params: array of {key, value}, original request parameters to resubmit as hidden fields
+    * htmltitle: string, the page title
+    * loadingtext: string, the text shown while submitting
+    * continuetext: string, the label of the manual submit button
+
+    Example context (json):
+    {
+        "url": "https://moodle.example.com/mod/kialo/lti_auth.php",
+        "params": [{"key": "nonce", "value": "abc"}, {"key": "response_type", "value": "id_token"}],
+        "htmltitle": "Loading",
+        "loadingtext": "Loading",
+        "continuetext": "Continue"
+    }
+}}
+<!DOCTYPE html>
+<html lang=en>
+<head>
+    <meta charset=utf-8>
+    <meta name=viewport content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name=theme-color content=#2c343d>
+    <meta name=apple-mobile-web-app-capable content=yes>
+    <meta name=apple-mobile-web-app-status-bar-style content=black>
+    <meta name=mobile-web-app-capable content=yes>
+    <meta name=referrer content=strict-origin-when-cross-origin>
+    <title lang=en>{{ htmltitle }}</title>
+    <meta name=robots content=noindex,follow>
+    <link rel=icon sizes=16x16 href="/mod/kialo/pix/monologo.png" type=image/png>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div class="kialo-loading-text">
+    <form action="{{ url }}" method="get" id="kialo-repost-form">
+        {{#params}}
+        <input type="hidden" name="{{ key }}" value="{{ value }}">
+        {{/params}}
+        <input type="hidden" name="repost" value="1">
+        <p class="kialo-loading-title">{{ loadingtext }}</p>
+        <noscript>
+            <button type="submit">{{ continuetext }}</button>
+        </noscript>
+    </form>
+    <div id="kialo-loading-spinner" class="kialo-spinner kialo-spinner--large kialo-spinner--prerender">
+        <div class="kialo-spinner__circle kialo-spinner__circle--1">
+            <div class="kialo-spinner__line">
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--left"></div>
+                </div>
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--right"></div>
+                </div>
+            </div>
+        </div>
+        <div class="kialo-spinner__circle kialo-spinner__circle--2">
+            <div class="kialo-spinner__line">
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--left"></div>
+                </div>
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--right"></div>
+                </div>
+            </div>
+        </div>
+        <div class="kialo-spinner__circle kialo-spinner__circle--3">
+            <div class="kialo-spinner__line">
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--left"></div>
+                </div>
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--right"></div>
+                </div>
+            </div>
+        </div>
+        <div class="kialo-spinner__circle kialo-spinner__circle--4">
+            <div class="kialo-spinner__line">
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--left"></div>
+                </div>
+                <div class="kialo-spinner__arc">
+                    <div class="kialo-spinner__arc-inner kialo-spinner__arc-inner--right"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript">
+    //<![CDATA[
+    // Submit on load (not inline) so the page paints the loading spinner before navigating away,
+    // matching the redirect loading page.
+    window.addEventListener("load", function() {
+        document.getElementById("kialo-repost-form").submit();
+    });
+    //]]>
+</script>
+</body>
+</html>

--- a/tests/kialo_view_test.php
+++ b/tests/kialo_view_test.php
@@ -245,6 +245,57 @@ final class kialo_view_test extends \advanced_testcase {
     }
 
     /**
+     * No repost is needed when the user has a valid Moodle session.
+     *
+     * @return void
+     * @covers \mod_kialo\kialo_view::needs_session_repost
+     */
+    public function test_needs_session_repost_logged_in(): void {
+        // The setUp() method already logs in a real user.
+        $this->assertFalse(kialo_view::needs_session_repost());
+    }
+
+    /**
+     * A repost is needed when there is no Moodle session, e.g. because the SameSite=Lax session cookie
+     * was withheld on the cross-site request from the embedded Kialo iframe.
+     *
+     * @return void
+     * @covers \mod_kialo\kialo_view::needs_session_repost
+     */
+    public function test_needs_session_repost_not_logged_in(): void {
+        $this->setUser(null);
+
+        // Guard against a leftover repost marker from another test masking the result.
+        $originalget = $_GET;
+        try {
+            unset($_GET['repost']);
+            $this->assertTrue(kialo_view::needs_session_repost());
+        } finally {
+            $_GET = $originalget;
+        }
+    }
+
+    /**
+     * Once a request has already been reposted, we must not repost again even if there is still no
+     * session, otherwise the page would reload forever. The normal login flow handles it instead.
+     *
+     * @return void
+     * @covers \mod_kialo\kialo_view::needs_session_repost
+     */
+    public function test_needs_session_repost_does_not_loop(): void {
+        $this->setUser(null);
+
+        // The GET repost carries the marker in the query string; it must stop a further repost.
+        $originalget = $_GET;
+        try {
+            $_GET['repost'] = '1';
+            $this->assertFalse(kialo_view::needs_session_repost());
+        } finally {
+            $_GET = $originalget;
+        }
+    }
+
+    /**
      * Tests writing an HTTP response.
      *
      * @return void

--- a/tests/repost_page_test.php
+++ b/tests/repost_page_test.php
@@ -1,0 +1,101 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests the cross-site repost page used to work around the SameSite=Lax session cookie (MDL-83526).
+ *
+ * @package    mod_kialo
+ * @category   test
+ * @copyright  2023 onwards, Kialo GmbH <support@kialo-edu.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_kialo;
+
+use mod_kialo\output\repost_page;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+/**
+ * Tests the cross-site repost page.
+ *
+ * @covers \mod_kialo\output\repost_page
+ */
+final class repost_page_test extends \advanced_testcase {
+    /**
+     * The exported template data should contain the repost URL and the POST params as key/value pairs.
+     *
+     * @return void
+     * @covers \mod_kialo\output\repost_page::export_for_template
+     */
+    public function test_export_for_template(): void {
+        $this->resetAfterTest();
+        global $PAGE;
+        $renderer = $PAGE->get_renderer('mod_kialo');
+
+        $url = 'https://moodle.example.com/mod/kialo/lti_auth.php';
+        $page = new repost_page($url, [
+            'nonce' => 'abc',
+            'response_type' => 'id_token',
+        ]);
+        $data = $page->export_for_template($renderer);
+
+        $this->assertEquals($url, $data->url);
+        $this->assertEquals([
+            ['key' => 'nonce', 'value' => 'abc'],
+            ['key' => 'response_type', 'value' => 'id_token'],
+        ], $data->params);
+        $this->assertNotEmpty($data->continuetext);
+    }
+
+    /**
+     * A GET launch must be reposted as a GET (the LTI library reads parameters from the query string
+     * for GET requests). The form must carry the original parameters as fields plus the repost marker,
+     * and auto-submit.
+     *
+     * @return void
+     * @covers \mod_kialo\output\repost_page
+     */
+    public function test_renders_autosubmitting_get_form(): void {
+        $this->resetAfterTest();
+        global $PAGE;
+        $renderer = $PAGE->get_renderer('mod_kialo');
+
+        $html = $renderer->render(new repost_page(
+            'https://moodle.example.com/mod/kialo/lti_auth.php',
+            ['nonce' => 'abc', 'lti_message_hint' => 'JWT123']
+        ));
+
+        // GET form posting to the bare endpoint, so the parameters end up in the query string.
+        $this->assertStringContainsString('method="get"', $html);
+        $this->assertStringContainsString('action="https://moodle.example.com/mod/kialo/lti_auth.php"', $html);
+
+        // The original parameters are resubmitted as hidden fields (incl. the crucial lti_message_hint).
+        $this->assertStringContainsString('name="nonce"', $html);
+        $this->assertStringContainsString('value="abc"', $html);
+        $this->assertStringContainsString('name="lti_message_hint"', $html);
+
+        // The repost marker prevents an infinite repost loop on the second request.
+        $this->assertStringContainsString('name="repost"', $html);
+
+        // It auto-submits via JavaScript, deferred to the load event so the spinner paints first.
+        $this->assertStringContainsString('kialo-repost-form', $html);
+        $this->assertStringContainsString('.submit()', $html);
+        $this->assertStringContainsString('addEventListener("load"', $html);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'mod_kialo';
 
 // See https://moodledev.io/docs/apis/commonfiles/version.php.
-$plugin->version = 2026040701;  // Must be incremented for each new release!
-$plugin->release = '1.6.0';  // Semantic version.
+$plugin->version = 2026062503;  // Must be incremented for each new release!
+$plugin->release = '1.6.1';  // Semantic version.
 
 // Officially we require PHP 7.4. The first Moodle version that requires this as a minimum is Moodle 4.1.
 // But technically this plugin also runs on older Moodle versions, as long as they run on PHP 7.4,


### PR DESCRIPTION
**Fix embedded Kialo discussions broken by Moodle's `SameSite=Lax` session cookie change**

### Problem
Since [MDL-83526](https://moodle.atlassian.net/browse/MDL-83526) (Moodle 4.5.12 / 5.0.8 / 5.1.5 / 5.2.1), the `MoodleSession` cookie defaults to `SameSite=Lax`. When a discussion is shown **embedded**, Kialo redirects the browser back to our LTI auth endpoint (`lti_auth.php`) from inside its cross-site iframe. The browser now withholds the `Lax` session cookie on that request, so `require_login()` fails and the user sees a login screen instead of the discussion. This affects both the embedded activity view and the discussion-selection dialog. ([MDL-88721](https://moodle.atlassian.net/browse/MDL-88721) tracks the upstream regression.)

### Fix
Adopt the same "same-site repost" technique Moodle core uses in its own `mod_lti` ([MDL-71887](https://moodle.atlassian.net/browse/MDL-71887), still in current `main`): when `lti_auth.php` is hit with no session, re-issue the identical request from a Moodle-origin page. The repost is same-site, so the `Lax` cookie is sent and authentication proceeds. A `repost` marker prevents loops; genuinely logged-out users fall through to the normal login.

### Changes
- `lti_auth.php`: detect the missing session and render a same-site repost page (with `header_remove('Set-Cookie')` so the cookieless hit can't clobber the real session).
- New `output\repost_page` renderable + `repost_page.mustache` (auto-submitting form, `<noscript>` fallback).
- `kialo_view::needs_session_repost()` helper + renderer method.
- Tests for the renderable and the repost decision logic.
- Version bump to 1.6.1.

Untouched: "new window" display mode, deep-link response handling, and grading/AGS endpoints.

### Testing
`phpcs` (moodle standard) and `php-cs-fixer` clean; full `mod_kialo_testsuite` green (96/96).

> Note: browsers that fully partition first-party state inside frames (Safari ITP / CHIPS) will still fall through to an in-frame login — no worse than before; "Display in new window" is the fallback.
